### PR TITLE
修改 更改logger的io方式为SetOutput

### DIFF
--- a/rotate.go
+++ b/rotate.go
@@ -83,7 +83,6 @@ func (rlogger *RotateLogger) forceRotateWithLock() {
 		}
 	}
 	rlogger.fp, _ = os.OpenFile(rlogger.absPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0666)
-	//rlogger.logger = log.New(rlogger.fp, rlogger.prefix, rlogger.flag)
 	rlogger.logger.SetOutput(rlogger.fp)
 }
 

--- a/rotate.go
+++ b/rotate.go
@@ -83,7 +83,8 @@ func (rlogger *RotateLogger) forceRotateWithLock() {
 		}
 	}
 	rlogger.fp, _ = os.OpenFile(rlogger.absPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0666)
-	rlogger.logger = log.New(rlogger.fp, rlogger.prefix, rlogger.flag)
+	//rlogger.logger = log.New(rlogger.fp, rlogger.prefix, rlogger.flag)
+	rlogger.logger.SetOutput(rlogger.fp)
 }
 
 func (rlogger *RotateLogger) rotate() {


### PR DESCRIPTION
我在其他服务使用rotate log时发现服务不能向新的文件中写入日志，
修改：`rlogger.logger = log.New(rlogger.fp, rlogger.prefix, rlogger.flag)`   
为：`rlogger.logger.SetOutput(rlogger.fp)` 
虽然解决了问题，但是并没有找出问题所在！